### PR TITLE
Add a parser for updateinfo.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,24 @@ rpm_packages.each do |rpm|
 end
 ```
 
+#### RepomdParser::UpdateinfoXmlParser
+
+Parses `updateinfo.xml`, which contains information about updates (patches) in the repository.
+
+`parse` method returns an array of `RepomdParser::Update` objects, each having a `packages` method returning an array of `RepomdParser::Reference` objects, representing the updated RPM packages.
+
+```ruby
+patches = RepomdParser::UpdateinfoXmlParser.new('updateinfo.xml').parse
+
+patches.each do |patch|
+  printf "title: %8s, description: %s\n", patch.title, patch.description
+
+  patch.packages.each do |rpm|
+    printf "arch: %8s, location: %s\n", rpm.arch, rpm.location
+  end
+end
+```
+
 #### RepomdParser::Reference
 
 Represents a file referenced in the metadata file. Has the following accessors:
@@ -72,6 +90,18 @@ RPM and DRPM files additionally have the following attributes:
 * `version`.
 * `release`.
 * `build_time`.
+
+#### RepomdParser::Update
+
+Represents an update, including the RPM packages that got updated:
+
+* `id`, a unique identifier for this update
+* `title`, a string summarizing the update
+* `description`, a more detailed description of this update
+* `severity`, e.g. Moderate, Critical
+* `type`, e.g. enhancement, security
+* `issued`, date and time this update was issued
+* `packages`, list of updated packages, represented as `RepomdParser::Reference` instances
 
 ## Caveats
 

--- a/lib/repomd_parser/update.rb
+++ b/lib/repomd_parser/update.rb
@@ -15,14 +15,27 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-module RepomdParser
-end
+class RepomdParser::Update
+  attr_accessor :id,
+                :title,
+                :description,
+                :severity,
+                :type,
+                :version,
+                :issued,
+                :packages
 
-require 'repomd_parser/version'
-require 'repomd_parser/reference'
-require 'repomd_parser/update'
-require 'repomd_parser/base_parser'
-require 'repomd_parser/repomd_xml_parser'
-require 'repomd_parser/deltainfo_xml_parser'
-require 'repomd_parser/primary_xml_parser'
-require 'repomd_parser/updateinfo_xml_parser'
+  def initialize(id:,
+                 title:,
+                 description:,
+                 severity:,
+                 type:,
+                 version:,
+                 issued:,
+                 packages:)
+    local_variables.each do |local_var|
+      method = "#{local_var}="
+      send(method, binding.local_variable_get(local_var)) if (respond_to?(method))
+    end
+  end
+end

--- a/lib/repomd_parser/updateinfo_xml_parser.rb
+++ b/lib/repomd_parser/updateinfo_xml_parser.rb
@@ -1,0 +1,90 @@
+# repomd_parser -- Ruby gem to parse RPM repository metadata
+# Copyright (C) 2018  Ivan Kapelyukhin, SUSE Linux GmbH
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+class RepomdParser::UpdateinfoXmlParser < RepomdParser::BaseParser
+
+  def initialize(filename)
+    @updates = []
+    super(filename)
+  end
+
+  def parse
+    super
+    @updates
+  end
+
+  def start_element(name, attrs = [])
+    @current_node = name.to_sym
+    if (name == 'update')
+      @update = {}
+      @update[:type] = get_attribute(attrs, 'type')
+      @update[:version] = get_attribute(attrs, 'version')
+    elsif (name == 'issued')
+      @update[:issued] = get_attribute(attrs, 'date')
+    elsif (name == 'package')
+      @package = {}
+      @package[:name] = get_attribute(attrs, 'name')
+      @package[:version] = get_attribute(attrs, 'version')
+      @package[:release] = get_attribute(attrs, 'release')
+      @package[:arch] = get_attribute(attrs, 'arch')
+    elsif (name == 'sum')
+      @package[:checksum_type] = get_attribute(attrs, 'type')
+    end
+  end
+
+  def characters(string)
+    if (%i[id title description severity].include? @current_node)
+      @update[@current_node] ||= ''
+      @update[@current_node] += string.strip
+    elsif (@current_node == :sum)
+      @package[:checksum] ||= ''
+      @package[:checksum] += string.strip
+    elsif (@current_node == :filename)
+      @package[:location] ||= ''
+      @package[:location] += string.strip
+    end
+  end
+
+  def end_element(name)
+    if (name == 'update')
+      @updates << RepomdParser::Update.new(
+        id: @update[:id],
+        title: @update[:title],
+        description: @update[:description],
+        severity: @update[:severity],
+        type: @update[:type],
+        version: @update[:version],
+        issued: Time.at(@update[:issued].to_i),
+        packages: @referenced_files
+      )
+      @referenced_files = []
+    elsif (name == 'package')
+      @referenced_files << RepomdParser::Reference.new(
+        location: @package[:location],
+        checksum_type: @package[:checksum_type],
+        checksum: @package[:checksum],
+        type: :rpm,
+        size: nil,
+        arch: @package[:arch],
+        version: @package[:version],
+        release: @package[:release],
+        name: @package[:name],
+      )
+    end
+  end
+
+end


### PR DESCRIPTION
This PR adds a new `RepomdParser::UpdateinfoXmlParser` and with it, a `RepomdParser::Update` class, representing individual updates. Each update comes with a list of `packages`. Details in the README.md changes.

@ikapelyukhin Please review and advise on the following questions:

- I haven't finished writing the specs. I wanted to ask you first if you could provide the real updateinfo.xml for your "apples and oranges" repo. I guess you have this somewhere on OBS, or did you handcraft it?

- Any caveats I might have missed?

Thanks!