### PR TITLE
Add support for parsing metadata from IO objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,23 @@ Alternatively, install as `gem install repomd_parser`.
 
 Parses `repomd.xml` -- the main repository metadata file, which references other metadata files.
 
-`parse` method returns an array of `RepomdParser::Reference`. 
+`parse` and `parse_file` methods return an array of `RepomdParser::Reference`.
+
+##### Using the `parse` method
 
 ```ruby
-metadata_files = RepomdParser::RepomdXmlParser.new('repomd.xml').parse
+File.open('repomd.xml') do |fh|
+  metadata_files = RepomdParser::RepomdXmlParser.new.parse(fh)
+  metadata_files.each do |metadata_file|
+    printf "type: %10s, location: %s\n", metadata_file.type, metadata_file.location
+  end
+end
+```
+
+##### Using the `parse_file` method
+
+```ruby
+metadata_files = RepomdParser::RepomdXmlParser.new.parse_file('repomd.xml')
 metadata_files.each do |metadata_file|
   printf "type: %10s, location: %s\n", metadata_file.type, metadata_file.location 
 end
@@ -33,10 +46,23 @@ end
 
 Parses `primary.xml`, which contains information about RPM packages in the repository.
 
-`parse` method returns an array of `RepomdParser::Reference`.
+`parse` and `parse_file` methods return an array of `RepomdParser::Reference`.
+
+##### Using the `parse` method
 
 ```ruby
-rpm_packages = RepomdParser::PrimaryXmlParser.new('primary.xml').parse
+File.open('primary.xml') do |fh|
+  rpm_packages = RepomdParser::PrimaryXmlParser.new.parse(fh)
+  rpm_packages.each do |rpm|
+    printf "arch: %8s, location: %s\n", rpm.arch, rpm.location
+  end
+end
+```
+
+##### Using the `parse_file` method
+
+```ruby
+rpm_packages = RepomdParser::PrimaryXmlParser.new.parse_file('primary.xml')
 rpm_packages.each do |rpm|
   printf "arch: %8s, location: %s\n", rpm.arch, rpm.location
 end
@@ -46,14 +72,53 @@ end
 
 Parses `deltainfo.xml`, which contains information about delta-RPM packages in the repository.
 
-`parse` method returns an array of `RepomdParser::Reference`.
+`parse` and `parse_file` methods return an array of `RepomdParser::Reference`.
+
+##### Using the `parse` method
 
 ```ruby
-rpm_packages = RepomdParser::DeltainfoXmlParser.new('deltainfo.xml').parse
+File.open('deltainfo.xml') do |fh|
+  rpm_packages = RepomdParser::DeltainfoXmlParser.new.parse(fh)
+  rpm_packages.each do |rpm|
+    printf "arch: %8s, location: %s\n", rpm.arch, rpm.location
+  end
+end
+```
+
+##### Using the `parse_file` method
+
+```ruby
+rpm_packages = RepomdParser::DeltainfoXmlParser.new.parse_file('deltainfo.xml')
 rpm_packages.each do |rpm|
   printf "arch: %8s, location: %s\n", rpm.arch, rpm.location
 end
 ```
+
+#### Compressed file support
+
+The gzip and Zstandard compression formats are supported. The `parse_file`
+method automatically decompresses files based on the filename, e.g.:
+
+```ruby
+rpm_packages = RepomdParser::PrimaryXmlParser.new.parse_file('primary.xml.gz')
+rpm_packages.each do |rpm|
+  printf "arch: %8s, location: %s\n", rpm.arch, rpm.location
+end
+```
+
+The `RepomdParser.decompress_io` helper is provided to handle
+decompression of IO objects for use with the `parse` method:
+
+```ruby
+filename = 'primary.xml.gz'
+io = RepomdParser.decompress_io(File.open(filename), filename)
+
+rpm_packages = RepomdParser::PrimaryXmlParser.new.parse(io)
+rpm_packages.each do |rpm|
+  printf "arch: %8s, location: %s\n", rpm.arch, rpm.location
+end
+```
+
 
 #### RepomdParser::Reference
 
@@ -75,7 +140,8 @@ RPM and DRPM files additionally have the following attributes:
 
 ## Caveats
 
-* Relies on the file extension to determine if the file is compressed (automatically decompresses `.gz` and `.zst` files)
+* File extension is used to determine file compression type (expected
+  extensions are `.gz` and `.zst` for gzip and Zstandard respectively)
 
 ## Development
 

--- a/lib/repomd_parser.rb
+++ b/lib/repomd_parser.rb
@@ -15,9 +15,6 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-module RepomdParser
-end
-
 require 'repomd_parser/version'
 require 'repomd_parser/reference'
 require 'repomd_parser/base_parser'
@@ -25,3 +22,13 @@ require 'repomd_parser/repomd_xml_parser'
 require 'repomd_parser/deltainfo_xml_parser'
 require 'repomd_parser/primary_xml_parser'
 require 'repomd_parser/zstd_reader'
+
+module RepomdParser
+  def self.decompress_io(io_object, filename)
+    case File.extname(filename)
+    when '.gz' then Zlib::GzipReader.new(io_object)
+    when '.zst' then RepomdParser::ZstdReader.new(io_object)
+    else io_object
+    end
+  end
+end

--- a/lib/repomd_parser/repomd_xml_parser.rb
+++ b/lib/repomd_parser/repomd_xml_parser.rb
@@ -16,13 +16,15 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 class RepomdParser::RepomdXmlParser
-  def initialize(filename)
-    @filename = filename
+  def parse_file(filename)
+    File.open(filename) do |fh|
+      parse(fh)
+    end
   end
 
-  def parse
+  def parse(io_object)
     files = []
-    xml = Nokogiri::XML(File.open(@filename))
+    xml = Nokogiri::XML(io_object)
 
     xml.xpath('/xmlns:repomd/xmlns:data').each do |data_node|
       type = data_node.attr('type').to_sym

--- a/lib/repomd_parser/version.rb
+++ b/lib/repomd_parser/version.rb
@@ -16,5 +16,5 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 module RepomdParser
-  VERSION = '0.1.6'.freeze
+  VERSION = '1.0.0'.freeze
 end

--- a/lib/repomd_parser/zstd_reader.rb
+++ b/lib/repomd_parser/zstd_reader.rb
@@ -17,15 +17,15 @@
 
 require 'zstd-ruby'
 
-class RepomdParser::ZstdReader < File
-  def initialize(*args)
-    super(*args)
+class RepomdParser::ZstdReader
+  def initialize(io_object)
+    @io = io_object
     @stream = Zstd::StreamingDecompress.new
     @buffer = ''
   end
 
   def read(len = nil, out = nil)
-    @buffer << @stream.decompress(super(len)) while @buffer.size < len && !eof
+    @buffer << @stream.decompress(@io.read(len)) while @buffer.size < len && !@io.eof
 
     if @buffer.size > len
       out = @buffer[0..len]
@@ -36,5 +36,9 @@ class RepomdParser::ZstdReader < File
     end
 
     out
+  end
+
+  def close
+    @io.close
   end
 end

--- a/spec/lib/repomd_parser/deltainfo_xml_parser_spec.rb
+++ b/spec/lib/repomd_parser/deltainfo_xml_parser_spec.rb
@@ -2,11 +2,11 @@ require 'repomd_parser'
 
 RSpec.describe RepomdParser::DeltainfoXmlParser do
   let(:parsed_files) do
-    described_class.new(
+    described_class.new.parse_file(
       file_fixture(
         'dummy_repo/repodata/a546b430098b8a3fb7d65493a9ce608fafcb32f451d0ce8bf85410191f347cc3-deltainfo.xml.gz'
       )
-    ).parse
+    )
   end
 
   it 'references drpm files' do

--- a/spec/lib/repomd_parser/primary_xml_parser_spec.rb
+++ b/spec/lib/repomd_parser/primary_xml_parser_spec.rb
@@ -69,11 +69,11 @@ RSpec.describe RepomdParser::PrimaryXmlParser do
 
     context 'XML compressed with Zstandard' do
       let(:parsed_files) do
-        described_class.new(
+        described_class.new.parse_file(
           file_fixture(
             'dummy_repo/repodata/0d499f39e90442b3f052681964debe48ac6e438252cee5fc2dd33002795026f1-primary.xml.zst'
           )
-        ).parse
+        )
       end
 
       it 'references rpm files' do
@@ -83,11 +83,11 @@ RSpec.describe RepomdParser::PrimaryXmlParser do
 
     context 'XML compressed with gzip' do
       let(:parsed_files) do
-        described_class.new(
+        described_class.new.parse_file(
           file_fixture(
             'dummy_repo/repodata/abf421e45af5cd686f050bab3d2a98e0a60d1b5ca3b07c86cb948fc1abfa675e-primary.xml.gz'
           )
-        ).parse
+        )
       end
 
       it 'references rpm files' do
@@ -97,11 +97,11 @@ RSpec.describe RepomdParser::PrimaryXmlParser do
 
     context 'plain XML' do
       let(:parsed_files) do
-        described_class.new(
+        described_class.new.parse_file(
           file_fixture(
             'dummy_repo/repodata/abf421e45af5cd686f050bab3d2a98e0a60d1b5ca3b07c86cb948fc1abfa675e-primary.xml'
           )
-        ).parse
+        )
       end
 
       it 'references rpm files' do

--- a/spec/lib/repomd_parser/repomd_xml_parser_spec.rb
+++ b/spec/lib/repomd_parser/repomd_xml_parser_spec.rb
@@ -1,7 +1,7 @@
 require 'repomd_parser'
 
 RSpec.describe RepomdParser::RepomdXmlParser do
-  let(:parsed_files) { described_class.new(file_fixture('dummy_repo/repodata/repomd.xml')).parse }
+  let(:parsed_files) { described_class.new.parse_file(file_fixture('dummy_repo/repodata/repomd.xml')) }
 
   it 'references repodata files' do
     expect(parsed_files).to eq [
@@ -36,7 +36,7 @@ RSpec.describe RepomdParser::RepomdXmlParser do
     ]
   end
 
-  let(:old_style_parsed_files) { described_class.new(file_fixture('old_style_repo/repodata/repomd.xml')).parse }
+  let(:old_style_parsed_files) { described_class.new.parse_file(file_fixture('old_style_repo/repodata/repomd.xml')) }
 
   it 'handles repomd.xml without size field' do
     expect(old_style_parsed_files).to eq [


### PR DESCRIPTION
Changed the interface for all parser classes in order to support supplying IO objects (e.g., `File` or `StringIO`) as data sources.

All parser classes now don't take any constructor arguments, instead the `parse` and `parse_file` methods expect IO objects and filenames as arguments respectively.

Closes #15.